### PR TITLE
Track correct cursor position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 npm-debug.log
 node_modules
+package-lock.json

--- a/lib/slides-preview-view.js
+++ b/lib/slides-preview-view.js
@@ -35,7 +35,7 @@ export default class SlidesView extends ScrollView{
   }
   trackSlide() {
     let count = 0
-    let cur = this.editor.getCursorScreenPosition()
+    let cur = this.editor.getCursorBufferPosition()
     let range = new Range(new Point(0, 1), cur)
     this.editor.scanInBufferRange(/(?:^|\n)(---?)(?:\n|$)/g, range,
       (found) => {

--- a/lib/slides-preview.js
+++ b/lib/slides-preview.js
@@ -41,6 +41,11 @@ export default {
     console.log('Slides was toggled!');
 
     editor = atom.workspace.getActiveTextEditor()
+    if (editor == null) {
+      console.error('No editor present');
+      return
+    }
+
     uri = "slides-preview://editor/"+editor.id
     console.log("uri", uri);
     target = atom.workspace.paneForURI(uri)


### PR DESCRIPTION
When soft wrapping is enabled the slides switch at the wrong position.